### PR TITLE
Updated html header for iOS web app support

### DIFF
--- a/partials/_head.php
+++ b/partials/_head.php
@@ -57,9 +57,12 @@ See more in /humans.txt
 
 	<!-- iOS Homescreen specials -->
 	<meta name="apple-mobile-web-app-title" content="Chalmers.it">
+	<meta name="apple-mobile-web-app-capable" content="yes">
+      	<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 	
 	<!-- Viewport setting -->
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1, user-scalable=no" />
+      
 	
 	<!-- Humanstxt.org -->
 	<link type="text/plain" rel="author" href="/humans.txt" />


### PR DESCRIPTION
For iOS (iPod Touch, iPhone & iPad)
Fixed so that Chalmers.it can be added to homescreen as a fullscreen webapp. Current implementation only adds a Safari Bookmark.
